### PR TITLE
refactor(graph.remove_vertex): dont call adjacency_list.get

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -82,13 +82,9 @@ impl<T: Eq + Hash + Clone + Debug> Graph<T> {
   }
 
   pub fn remove_vertex(&mut self, vertex: &T) -> Result<(), VertexNotFoundError<T>> {
-    match self.adjacency_list.get(vertex) {
+    match self.adjacency_list.remove(vertex) {
       None => Err(VertexNotFoundError(vertex.clone())),
-      Some(_) => {
-        self.adjacency_list.remove(&vertex);
-
-        Ok(())
-      }
+      Some(_) => Ok(()),
     }
   }
 


### PR DESCRIPTION
- No need to call `adjacency_list.get` when removing vertex from graph